### PR TITLE
package.js: update libxmljs to 0.14.0

### DIFF
--- a/package.js
+++ b/package.js
@@ -9,7 +9,7 @@ if(!Package.onUse) Package.onUse = Package.on_use;
 
 Npm.depends({
 	node_xslt: "0.1.9",
-	libxmljs: "0.12.0"
+	libxmljs: "0.14.0"
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
Get the latest goodies from upstream:
- add support for RELAX NG schema validation
- improve HTML parsing errors when root node is missing
- newer nan to work around v8 issues
